### PR TITLE
Add FontMapper API

### DIFF
--- a/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
+++ b/CalligraphySample/src/main/java/uk/co/chrisjenx/calligraphy/sample/CalligraphyApplication.java
@@ -5,6 +5,7 @@ import android.app.Application;
 import io.github.inflationx.viewpump.ViewPump;
 import uk.co.chrisjenx.calligraphy3.CalligraphyConfig;
 import uk.co.chrisjenx.calligraphy3.CalligraphyInterceptor;
+import uk.co.chrisjenx.calligraphy3.FontMapper;
 
 /**
  * Created by chris on 06/05/2014.
@@ -20,6 +21,12 @@ public class CalligraphyApplication extends Application {
                         new CalligraphyConfig.Builder()
                                 .setDefaultFontPath("fonts/Roboto-ThinItalic.ttf")
                                 .setFontAttrId(R.attr.fontPath)
+                                .setFontMapper(new FontMapper() {
+                                    @Override
+                                    public String map(String font) {
+                                        return font;
+                                    }
+                                })
                                 .addCustomViewWithSetTypeface(CustomViewWithTypefaceSupport.class)
                                 .addCustomStyle(TextField.class, R.attr.textFieldStyle)
                                 .build()))

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy3/Calligraphy.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy3/Calligraphy.java
@@ -144,6 +144,8 @@ class Calligraphy {
                     textViewFont = CalligraphyUtils.pullFontPathFromTheme(context, styleForTextView[0], mAttributeId);
             }
 
+            textViewFont = applyFontMapper(textViewFont);
+
             // Still need to defer the Native action bar, appcompat-v7:21+ uses the Toolbar underneath. But won't match these anyway.
             final boolean deferred = matchesResourceIdName(view, ACTION_BAR_TITLE) || matchesResourceIdName(view, ACTION_BAR_SUBTITLE);
 
@@ -160,6 +162,7 @@ class Calligraphy {
         // Try to set typeface for custom views using interface method or via reflection if available
         if (view instanceof HasTypeface) {
             String textViewFont = resolveFontPath(context, attrs);
+            textViewFont = applyFontMapper(textViewFont);
             Typeface typeface = getDefaultTypeface(context, textViewFont);
             if (typeface != null) {
                 ((HasTypeface) view).setTypeface(typeface);
@@ -167,6 +170,7 @@ class Calligraphy {
         } else if (mCalligraphyConfig.isCustomViewTypefaceSupport() && mCalligraphyConfig.isCustomViewHasTypeface(view)) {
             final Method setTypeface = ReflectionUtils.getMethod(view.getClass(), "setTypeface");
             String fontPath = resolveFontPath(context, attrs);
+            fontPath = applyFontMapper(fontPath);
             Typeface typeface = getDefaultTypeface(context, fontPath);
             if (setTypeface != null && typeface != null) {
                 ReflectionUtils.invokeMethod(view, setTypeface, typeface);
@@ -203,6 +207,11 @@ class Calligraphy {
         }
 
         return textViewFont;
+    }
+
+    private String applyFontMapper(String textViewFont) {
+        FontMapper fontMapper = mCalligraphyConfig.getFontMapper();
+        return fontMapper != null ? fontMapper.map(textViewFont) : textViewFont;
     }
 
     private static class ToolbarLayoutListener implements ViewTreeObserver.OnGlobalLayoutListener {

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy3/CalligraphyConfig.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy3/CalligraphyConfig.java
@@ -85,6 +85,10 @@ public class CalligraphyConfig {
      * @see CalligraphyConfig.Builder#addCustomViewWithSetTypeface(Class)
      */
     private final Set<Class<?>> hasTypefaceViews;
+    /**
+     * An object that can map a resolved font name to another font name.
+     */
+    private final FontMapper mFontMapper;
 
     private CalligraphyConfig(Builder builder) {
         mIsFontSet = builder.isFontSet;
@@ -95,6 +99,7 @@ public class CalligraphyConfig {
         tempMap.putAll(builder.mStyleClassMap);
         mClassStyleAttributeMap = Collections.unmodifiableMap(tempMap);
         hasTypefaceViews = Collections.unmodifiableSet(builder.mHasTypefaceClasses);
+        mFontMapper = builder.fontMapper;
     }
 
     /**
@@ -130,6 +135,10 @@ public class CalligraphyConfig {
         return mAttrId;
     }
 
+    public FontMapper getFontMapper() {
+        return mFontMapper;
+    }
+
     public static class Builder {
         /**
          * Default AttrID if not set.
@@ -157,6 +166,8 @@ public class CalligraphyConfig {
         private Map<Class<? extends TextView>, Integer> mStyleClassMap = new HashMap<>();
 
         private Set<Class<?>> mHasTypefaceClasses = new HashSet<>();
+
+        private FontMapper fontMapper;
 
         /**
          * This defaults to R.attr.fontPath. So only override if you want to use your own attrId.
@@ -210,6 +221,11 @@ public class CalligraphyConfig {
         public Builder addCustomViewWithSetTypeface(Class<?> clazz) {
             customViewTypefaceSupport = true;
             mHasTypefaceClasses.add(clazz);
+            return this;
+        }
+
+        public Builder setFontMapper(FontMapper fontMapper) {
+            this.fontMapper = fontMapper;
             return this;
         }
 

--- a/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy3/FontMapper.java
+++ b/calligraphy/src/main/java/uk/co/chrisjenx/calligraphy3/FontMapper.java
@@ -1,0 +1,5 @@
+package uk.co.chrisjenx.calligraphy3;
+
+public interface FontMapper {
+    String map(String font);
+}


### PR DESCRIPTION
The idea behind this would be to have a default font name applied via a theme, style, text appearance, or on the view, but when the font is resolved, we provide a hook to allow for interception of the font name and to optionally return a different font name to actually use.