### PR TITLE
Prepare for 3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,22 +1,25 @@
-#Changelog
+# Changelog
 
-#2.2.0 (05/04/2016)
+## 3.0.0 (05/01/2017)
+- **BREAKING CHANGE** This library has been refactored into a [ViewPump](https://github.com/InflationX/ViewPump) interceptor 
+
+## 2.2.0 (05/04/2016)
 - Added AppCompat Styles (AppCompatTextView will now pickup textViewStyle etc). Thanks @paul-turner
 - Fix for Toolbar not inflating `TextView`s upfront.
 
-#2.1.0 (27/04/2015)
+## 2.1.0 (27/04/2015)
 - Fixed #155, We now clone correctly.
 - Added Styles for Custom Views. (`builder.addCustomStyle(ToggleButton.class, android.R.attr.buttonStyleToggle)`)
 
-#2.0.2 (05/01/2015)
+## 2.0.2 (05/01/2015)
 - Fixed `CalligraphyConfig.Builder` missing return statements.
 - Fixed `createView()` getting the wrong parent context, Fixed: #135, #120
 
-#2.0.1 (28/01/2014)
+## 2.0.1 (28/01/2014)
 - Throw exception on passing null into `CalligraphySpan`
 - Fixed memory bug with `Toolbar`. [@dlew](https://github.com/dlew)
 
-#2.0.0 (16/01/2014)
+## 2.0.0 (16/01/2014)
 **Breaking changes**
 This is a massive rewrite of the interception model. Look at `CalligraphyLayoutInflater` and
 `CalligraphyConfig` for more information on options and changes.
@@ -32,42 +35,42 @@ Notable changes:
 - We wrap Factory not disturbing underlying factory and layout inflater invocation.
 - Better support for `cloneInContext()` which the compat library uses heavily.
 
-#1.2.0 (20/10/2014)
+## 1.2.0 (20/10/2014)
 - Fixes issues with `appcompat-v7:21+` (uses underlying `Toolbar` impl).
 - Lollipop support.
 - Fast path view with font already set by us.
 
-#1.1.0 (02/08/2014)
+## 1.1.0 (02/08/2014)
 - Fixes ActionBar Title/SubTitle `textStyles`.
 - Fixes `textAllCaps` bug, now works correctly.
 - Fixes some `Spannable` issues reported, we are more careful what we apply `Spannable`'s too now.
 - Fixes missing Typeface on hint text on `EditText`/`AutoComplete`.
 - Fixes empty source and javadoc jars on maven.
 
-#1.0.0 (05/07/2014)
+## 1.0.0 (05/07/2014)
 - Added ActionBar Title/SubTitle support.
 - Toast support via default style/or TextView theme style.
 - Removed FontFamily parsing as it lead to users not being able to use `fontFamily`
 - Added TextAppearance Support - Thanks [@codebutler](https://github.com/codebutler) & [@loganj](https://github.com/loganj)
 - Default Font no longer required.
 
-#0.8/9 (Skipped major API change)
+## 0.8/9 (Skipped major API change)
 
-#0.7.1 (22/04/2014)
+## 0.7.1 (22/04/2014)
 - Fixed Resources not found Exception - [@Smuldr](https://github.com/Smuldr)
 
-#0.7.0 (28/01/2014)
+## 0.7.0 (28/01/2014)
 - Added Anti-aliasing support
 - Added custom font attribute support - Thanks [@Roman Zhilich](https://github.com/RomanZhilich)
 - Changed Maven groupId to `uk.co.chrisjenx` artifact is now `calligraphy`. `compile 'uk.co.chrisjenx:calligraphy:0.+'`
 
-#0.6.0 (02/01/2014)
+## 0.6.0 (02/01/2014)
 - Supports all Android implementations of `TextView`
 - Supports Custom `TextView`s - Thanks [@mironov-nsk](https://github.com/mironov-nsk)
 - Caches none found fonts as null
 
-#0.5.0
+## 0.5.0
 - Added support for `Button` class
 
-#0.4.0
+## 0.4.0
 - Initial Release

--- a/CalligraphySample/build.gradle
+++ b/CalligraphySample/build.gradle
@@ -24,7 +24,7 @@ android {
 
 dependencies {
     compile project(':calligraphy')
-    compile 'io.github.inflationx:viewpump:0.1.1-SNAPSHOT'
+    compile 'io.github.inflationx:viewpump:1.0.0'
     compile 'com.android.support:support-v4:24.0.0'
     compile 'com.android.support:appcompat-v7:24.0.0'
 

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Are you fed up of Custom Views to set fonts? Or traversing the ViewTree to find 
 
 ### Dependency
 
-Include the dependency [Download (.aar)](http://search.maven.org/remotecontent?filepath=uk/co/chrisjenx/calligraphy3/3.0.0-SNAPSHOT/calligraphy3-3.0.0-SNAPSHOT.aar) as well as the [ViewPump](https://github.com/InflationX/ViewPump) library:
+Include the dependency [Download (.aar)](http://search.maven.org/remotecontent?filepath=uk/co/chrisjenx/calligraphy3/3.0.0/calligraphy3-3.0.0.aar) as well as the [ViewPump](https://github.com/InflationX/ViewPump) library:
 
 ```groovy
 dependencies {
-    compile 'uk.co.chrisjenx:calligraphy3:3.0.0-SNAPSHOT'
-    compile 'io.github.inflationx:viewpump:0.1.1-SNAPSHOT'
+    compile 'uk.co.chrisjenx:calligraphy3:3.0.0'
+    compile 'io.github.inflationx:viewpump:1.0.0'
 }
 ```
 ### Add Fonts

--- a/calligraphy/build.gradle
+++ b/calligraphy/build.gradle
@@ -22,7 +22,7 @@ android {
 
 dependencies {
     provided 'com.android.support:appcompat-v7:25.0.1'
-    compile 'io.github.inflationx:viewpump:0.1.1-SNAPSHOT'
+    compile 'io.github.inflationx:viewpump:1.0.0'
 }
 
 apply from: rootProject.file('gradle/deploy.gradle')

--- a/gradle.properties
+++ b/gradle.properties
@@ -19,7 +19,7 @@
 
 GROUP=io.github.inflationx
 VERSION_NAME=3.0.0
-VERSION_CODE=30
+VERSION_CODE=31
 
 POM_PACKAGING=aar
 POM_URL=https://github.com/InflationX/Calligraphy


### PR DESCRIPTION
Update changelog, readme, version number, and dependency versions

Depends on PR and release of [ViewPump 1.0.0](https://github.com/InflationX/ViewPump/pull/10)