### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,8 @@ Include the dependency [Download (.aar)](http://search.maven.org/remotecontent?f
 
 ```groovy
 dependencies {
-    compile 'io.github.inflationx:calligraphy3:3.0.0'
-    compile 'io.github.inflationx:viewpump:1.0.0'
+    implementation 'io.github.inflationx:calligraphy3:3.0.0'
+    implementation 'io.github.inflationx:viewpump:1.0.0'
 }
 ```
 ### Add Fonts


### PR DESCRIPTION
'compile' keyword is deprecated during the last update of gradle