### PR TITLE
Support setting font on view with theme attribute

### DIFF
--- a/CalligraphySample/src/main/res/layout/fragment_main.xml
+++ b/CalligraphySample/src/main/res/layout/fragment_main.xml
@@ -28,6 +28,12 @@
             android:text="@string/defined_fontpath_view"/>
 
         <TextView
+            fontPath="?customAttrFontPath"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/defined_fontpath_view_theme_attr"/>
+
+        <TextView
             fontPath="fonts/Roboto-None.ttf"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/CalligraphySample/src/main/res/values/attrs.xml
+++ b/CalligraphySample/src/main/res/values/attrs.xml
@@ -2,5 +2,6 @@
 <resources>
 
     <attr name="textFieldStyle" format="reference"/>
+    <attr name="customAttrFontPath" format="reference|string"/>
 
 </resources>

--- a/CalligraphySample/src/main/res/values/strings.xml
+++ b/CalligraphySample/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="defined_gtw">\nThis is text set by the gtw style.\n</string>
     <string name="default_theme">\nThis is text set by the default theme fontPath.\n</string>
     <string name="defined_fontpath_view">\nThis has a font path set to Roboto Bold, on the View.\n</string>
+    <string name="defined_fontpath_view_theme_attr">\nThis has a font path set to a theme attr declaring fontPath as Oswald</string>
     <string name="defined_incorrect">\nThis has a fontPath set to a font file that does not exist, it goes back to the default.\n</string>
     <string name="defined_in_style">\nThis has the font path defined in the style as Roboto Condensed.\n</string>
     <string name="defined_in_appears_style">\nThis has the font path defined in the Styles TextAppearance as Roboto Condensed.\n</string>

--- a/CalligraphySample/src/main/res/values/styles.xml
+++ b/CalligraphySample/src/main/res/values/styles.xml
@@ -11,6 +11,8 @@
         <item name="android:actionBarStyle">@style/AppTheme.ActionBar</item>
         <!-- Custom Style Attribute-->
         <item name="textFieldStyle">@style/TextField</item>
+        <!-- Custom font path theme attribute -->
+        <item name="customAttrFontPath">fonts/Oswald-Stencbab.ttf</item>
     </style>
 
     <!-- AppTheme ActionBar Style -->

--- a/calligraphy/src/main/java/io/github/inflationx/calligraphy3/CalligraphyUtils.java
+++ b/calligraphy/src/main/java/io/github/inflationx/calligraphy3/CalligraphyUtils.java
@@ -167,9 +167,23 @@ public final class CalligraphyUtils {
         }
 
         final int stringResourceId = attrs.getAttributeResourceValue(null, attributeName, -1);
-        return stringResourceId > 0
+        String fontPath = stringResourceId > 0
                 ? context.getString(stringResourceId)
                 : attrs.getAttributeValue(null, attributeName);
+
+        if (fontPath != null && fontPath.startsWith("?") && fontPath.length() > 1) {
+            String fontPathValueAttr = fontPath.substring(1);
+            if (TextUtils.isDigitsOnly(fontPathValueAttr)) {
+                int fontPathValueAttrRes = Integer.parseInt(fontPathValueAttr);
+                TypedValue typedValue = new TypedValue();
+                context.getTheme().resolveAttribute(fontPathValueAttrRes, typedValue, true);
+                if (typedValue.type == TypedValue.TYPE_STRING && typedValue.string != null) {
+                    fontPath = typedValue.string.toString();
+                }
+            }
+        }
+
+        return fontPath;
     }
 
     /**


### PR DESCRIPTION
Resolves #12 by converting unfound fontPaths with theme attr notation followed by a resId to their appropriate looked-up value in the theme

<img width="618" alt="screen shot 2019-01-17 at 10 38 13 pm" src="https://user-images.githubusercontent.com/3178606/51369829-d3664180-1aa9-11e9-833d-63e199a3e2c4.png">
