### PR TITLE
allow injection of fonts directly into the font cache

### DIFF
--- a/calligraphy/src/main/java/io/github/inflationx/calligraphy3/TypefaceUtils.java
+++ b/calligraphy/src/main/java/io/github/inflationx/calligraphy3/TypefaceUtils.java
@@ -73,6 +73,17 @@ public final class TypefaceUtils {
         return typeface != null && sCachedFonts.containsValue(typeface);
     }
 
+
+    /**
+     * Inject a specific font into the font cache to be resolved for a given font path
+     * This allows arbitrary fonts to be loaded dynamically at runtime from any source (e.g from disk)
+     * @param path
+     * @param typeface
+     */
+    public static void installFont(String path, Typeface typeface){
+        sCachedFonts.put(path, typeface);
+    }
+
     private TypefaceUtils() {
     }
 }

--- a/calligraphy/src/main/java/io/github/inflationx/calligraphy3/TypefaceUtils.java
+++ b/calligraphy/src/main/java/io/github/inflationx/calligraphy3/TypefaceUtils.java
@@ -84,6 +84,16 @@ public final class TypefaceUtils {
         sCachedFonts.put(path, typeface);
     }
 
+    /**
+     * 'Uninstall' a font from the font cache
+     * @param path
+     */
+    public static void uninstallFont(String path){
+        if(sCachedFonts.containsKey(path)){
+            sCachedFonts.remove(path);
+        }
+    }
+
     private TypefaceUtils() {
     }
 }


### PR DESCRIPTION
the motive here was to allow me to load fonts from the file system rather than the assets folder