### PR TITLE
Check current toolbar's subTitle and set valid subTitle

### DIFF
--- a/calligraphy/src/main/java/io/github/inflationx/calligraphy3/Calligraphy.java
+++ b/calligraphy/src/main/java/io/github/inflationx/calligraphy3/Calligraphy.java
@@ -250,7 +250,12 @@ class Calligraphy {
                 }
             }
             removeSelf(toolbar);
-            toolbar.setSubtitle(originalSubTitle);
+            String subTitle = toolbar.getSubtitle().toString();
+            if (BLANK.equals(subTitle)) {
+                toolbar.setSubtitle(originalSubTitle);
+            } else {
+                toolbar.setSubtitle(subTitle);
+            }
         }
 
         private void removeSelf(final Toolbar toolbar) {// Our dark deed is done


### PR DESCRIPTION
## Problem
- If I try set toolbar's subtitle in `onCreate()`(not xml), subtitle is not shown.
- sample code work, but I don't want use `postDelay()`, `post()`
https://github.com/InflationX/Calligraphy/blob/881f11fe37491aee56ae155eb1ae4ff0599373ae/CalligraphySample/src/main/java/io/github/inflationx/calligraphy3/sample/MainActivity.java#L34
```java
final Handler handler = new Handler(Looper.getMainLooper());
handler.postDelayed(new Runnable() {
    @Override
    public void run() {
        toolbar.setSubtitle("Added subtitle");
    }
}, 1000);
```

## Reason
1. When activity start `ToolbarLayoutListener` get toolbar's original subTitle and set blank string
https://github.com/InflationX/Calligraphy/blob/881f11fe37491aee56ae155eb1ae4ff0599373ae/calligraphy/src/main/java/io/github/inflationx/calligraphy3/Calligraphy.java#L231
2. After view shown, `ToolbarLayoutListener` set original subTitle to toolbar
https://github.com/InflationX/Calligraphy/blob/881f11fe37491aee56ae155eb1ae4ff0599373ae/calligraphy/src/main/java/io/github/inflationx/calligraphy3/Calligraphy.java#L253

- But that is problem. set  toolbar's subtitle in `onCreate()` is ignore.


## Solution
- After view shown, `ToolbarLayoutListener` check toolbar's current subTitle.
- If toolbar's current subTitle is `BLANK`, use original subtitle.
- If toolbar's current subTitle is not `BLANK`, user set toolbar's subtitle. so toolbar use current subtitle.